### PR TITLE
update symbols server url

### DIFF
--- a/scrapesymbols/gathersymbols.py
+++ b/scrapesymbols/gathersymbols.py
@@ -25,7 +25,7 @@ else:
         '/lib',
         '/usr/lib',
     ]
-SYMBOL_SERVER_URL = 'https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/'
+SYMBOL_SERVER_URL = 'https://symbols.mozilla.org/'
 MISSING_SYMBOLS_URL = 'https://crash-analysis.mozilla.com/crash_analysis/{date}/{date}-missing-symbols.txt'
 
 def should_process(f, platform=sys.platform):


### PR DESCRIPTION
gathersymbols is accessing the public symbols AWS S3 bucket directly rather than going through the Mozilla Symbols Server and getting redirected. We're planning to migrate to GCP and after we migrate, there won't be any AWS S3 bucket.

This fixes gathersymbols so that it works with our current setup as well as the setup we'll have after the GCP migration.

Details: https://bugzilla.mozilla.org/show_bug.cgi?id=1831952